### PR TITLE
Added support for Scientific Linux

### DIFF
--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -4,7 +4,7 @@ class dhcp::server::install {
     ubuntu, debian: {
       $package_name = "isc-dhcp-server"
     }
-    centos, redhat: {
+    centos, redhat, Scientific: {
       $package_name = "dhcp"
     }
     default: {

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -4,7 +4,7 @@ class dhcp::server::service {
     ubuntu, debian: {
       $service_name = "isc-dhcp-server"
     }
-    centos, redhat: {
+    centos, redhat, Scientific: {
       $service_name = "dhcpd"
     }
     default: {


### PR DESCRIPTION
Scientific Linux is a RHEL clone and can be treated like Red Hat or CentOS.

$ facter operatingsystem
Scientific
